### PR TITLE
fix: Change version regex to raw string

### DIFF
--- a/h5plexos/query/solution.py
+++ b/h5plexos/query/solution.py
@@ -7,7 +7,7 @@ import re
 def issequence(x):
     return hasattr(x, '__iter__')
 
-version_rgx = re.compile("^v(\d+)\.(\d+)\.(\d+)$")
+version_rgx = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 
 class PLEXOSSolution:
 


### PR DESCRIPTION
This PR gets rid of a SyntaxWarning that users may see:

```
 SyntaxWarning: invalid escape sequence '\d'
  version_rgx = re.compile("^v(\d+)\.(\d+)\.(\d+)$")
```