### PR TITLE
feat: Add `pluralize = True` as kwarg to `query_object_property`

### DIFF
--- a/h5plexos/query/solution.py
+++ b/h5plexos/query/solution.py
@@ -88,9 +88,9 @@ class PLEXOSSolution:
     def query_object_property(
             self, object_class, prop,
             names=slice(None), categories=slice(None),
-            timescale="interval", timespan=slice(None), phase="ST"):
+            timescale="interval", timespan=slice(None), phase="ST", pluralize=True):
         
-        if ((0,6,0) <= self.version and self.version < (0,7,0)):
+        if ((0,6,0) <= self.version and self.version < (0,7,0)) and pluralize:
             object_class += "s"
         
         obj_lookup = self.objects[object_class].loc[(categories, names),].sort_values()


### PR DESCRIPTION
This PR adds `pluralize = True` as a kwarg to `db.query_object_property`

This allows using this function for extracting data from `object_class`s that don't conform to common pluralization patterns or singular `object_class`s, e.g. with this PR the following code will work:

```python
db.query_object_property(
    object_class="batteries",
    prop="Generation",
    timescale="year",
    phase="LT",
    pluralize=False,
)

db.query_object_property(
    object_class="power2x",
    prop="Installed Capacity",
    timescale="year",
    phase="LT",
    pluralize=False
)
```